### PR TITLE
Close db connection before spawning worker.  Addresses #144

### DIFF
--- a/django_q/cluster.py
+++ b/django_q/cluster.py
@@ -174,6 +174,7 @@ class Sentinel(object):
             logger.error(_("reincarnated pusher {} after sudden death").format(process.name))
         else:
             self.pool.remove(process)
+            db.connection.close()
             self.spawn_worker()
             if self.timeout and int(process.timer.value) == 0:
                 # only need to terminate on timeout, otherwise we risk destabilizing the queues


### PR DESCRIPTION
Having noticed that when the cluster is spawned the db connection is closed immediately prior to spawning said processes, I tested this solution successfully on my local install.  With this one extra line in place, I am no longer experiencing the "ERROR connection already closed" when a worker recycles.